### PR TITLE
Record transaction in Observery's vault

### DIFF
--- a/cdm-support/src/test/kotlin/net/corda/cdmsupport/testflow/TestObservableFlow.kt
+++ b/cdm-support/src/test/kotlin/net/corda/cdmsupport/testflow/TestObservableFlow.kt
@@ -23,6 +23,6 @@ class ReceiveObservableFlow(private val otherSideSession: FlowSession) : FlowLog
     override fun call() {
         // Start the matching side of SendTransactionFlow above, but tell it to record all visible states even
         // though they (as far as the node can tell) are nothing to do with us.
-        subFlow(ReceiveTransactionFlow(otherSideSession, false, StatesToRecord.ALL_VISIBLE))
+        subFlow(ReceiveTransactionFlow(otherSideSession, true, StatesToRecord.ALL_VISIBLE))
     }
 }


### PR DESCRIPTION
As per comment in ReceiveTransactionFlow:
 * Please note that it will *not* store the transaction to the vault unless that is explicitly requested and checkSufficientSignatures is true.
 * Setting statesToRecord to anything else when checkSufficientSignatures is false will *not* update the vault.