### PR TITLE
Removing the filtration of mapPartiesToCordaX500Name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
 
 You can clone the project from here:
 
-https://github.com/corda/derivhack/tree/release/01.10.2019
+https://github.com/corda/barclays-derivhack
 
 ##### Load Project in Dev Env - IntelliJ
 

--- a/cdm-support/src/main/kotlin/net/corda/cdmsupport/extensions/ExecutionExtensions.kt
+++ b/cdm-support/src/main/kotlin/net/corda/cdmsupport/extensions/ExecutionExtensions.kt
@@ -25,15 +25,8 @@ fun Execution.createExecutionWithPartiesFromEvent(event: Event) : Execution {
 
 fun Execution.mapPartyToCordaX500ForExecution(serviceHub : ServiceHub) : List<Party>{
 
-    //We're excluding the client from this trade
-    val client = this.partyRole
-            .filter { it.role == PartyRoleEnum.CLIENT }
-            .map { it.partyReference.globalReference }
-
     val parties : MutableSet<Party> = mutableSetOf()
-    this.party
-            .filter { !client.contains(it.globalReference) }
-            .forEach { parties.add(serviceHub.identityService
+    this.party.forEach { parties.add(serviceHub.identityService
             .wellKnownPartyFromX500Name(CordaX500Name.parse("O=${it.value.name.value},L=New York,C=US"))!!) }
 
     return parties.toList()
@@ -41,15 +34,8 @@ fun Execution.mapPartyToCordaX500ForExecution(serviceHub : ServiceHub) : List<Pa
 
 fun Execution.mapPartyToCordaX500ForAllocation(serviceHub : ServiceHub) : List<Party>{
 
-    //We're excluding the counterparty broker from this trade
-    val client = this.partyRole
-            .filter { it.role == PartyRoleEnum.COUNTERPARTY }
-            .map { it.partyReference.globalReference }
-
     val parties : MutableSet<Party> = mutableSetOf()
-    this.party
-            .filter { !client.contains(it.globalReference) }
-            .forEach { parties.add(serviceHub.identityService
+    this.party.forEach { parties.add(serviceHub.identityService
             .wellKnownPartyFromX500Name(CordaX500Name.parse("O=${it.value.name.value},L=New York,C=US"))!!) }
 
     return parties.toList()


### PR DESCRIPTION
Adding ready to use buildAllocationEvent func in CDMBuilders, using the fixed Allocate function from CDM 2.5.17